### PR TITLE
Add decimal 128 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Serializes to `str` in `model_dump()` (e.g., `"123.45"`)
   - Integrated into schema generation with `bsonType: "decimal"`
 - New type mapping in `TYPE_MAP`: `BSONDecimal128 -> "decimal"`
+- **Added `pymongo` as a required dependency** to enable support for `Decimal128`
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.0
+
+- Support for `BSONDecimal128` as a custom scalar type:
+  - Accepts `str`, `Decimal`, or `Decimal128`
+  - Converts input to MongoDB's `Decimal128` format
+  - Serializes to `str` in `model_dump()` (e.g., `"123.45"`)
+  - Integrated into schema generation with `bsonType: "decimal"`
+- New type mapping in `TYPE_MAP`: `BSONDecimal128 -> "decimal"`
+
 ## 1.0.0
 
 Initial stable release of `mongo-validations-generator`.

--- a/README.md
+++ b/README.md
@@ -102,17 +102,18 @@ print(json.dumps(Product.generate_validation_rules("Product"), indent=2))
 
 The following BSON types are currently supported by the schema generator:
 
-| Python Type                    | BSON Type  | Notes                                                         |
-| ------------------------------ | ---------- | ------------------------------------------------------------- |
-| `str`                          | `"string"` |                                                               |
-| `int`                          | `"int"`    |                                                               |
-| `float`                        | `"double"` |                                                               |
-| `bool`                         | `"bool"`   |                                                               |
-| `list[...]`                    | `"array"`  | Supports nested items, constraints, and unions                |
-| `None` / `Optional[...]`       | `"null"`   | Supports `Union[Type, None]` and `Optional[...]`              |
-| `Annotated[int, Long]`         | `"long"`   | Use `Annotated[int, Long]` to convert to `"long"`             |
-| `Literal[...]`                 | `"enum"`   | Will emit enum values and infer BSON type if homogeneous      |
-| `MongoValidator` subclass      | `"object"` | Nested objects are fully supported                            |
-| `Annotated[list[T], Len(...)]` | `"array"`  | Adds `minItems` and `maxItems` constraints to list validation |
+| Python Type                    | BSON Type   | Notes                                                                |
+| ------------------------------ | ----------- | -------------------------------------------------------------------- |
+| `str`                          | `"string"`  |                                                                      |
+| `int`                          | `"int"`     |                                                                      |
+| `float`                        | `"double"`  |                                                                      |
+| `bool`                         | `"bool"`    |                                                                      |
+| `list[...]`                    | `"array"`   | Supports nested items, constraints, and unions                       |
+| `None` / `Optional[...]`       | `"null"`    | Supports `Union[Type, None]` and `Optional[...]`                     |
+| `Annotated[int, Long]`         | `"long"`    | Use `Annotated[int, Long]` to convert to `"long"`                    |
+| `Literal[...]`                 | `"enum"`    | Will emit enum values and infer BSON type if homogeneous             |
+| `MongoValidator` subclass      | `"object"`  | Nested objects are fully supported                                   |
+| `Annotated[list[T], Len(...)]` | `"array"`   | Adds `minItems` and `maxItems` constraints to list validation        |
+| `BSONDecimal128`               | `"decimal"` | Outputs a decimal-compatible field using MongoDB's Decimal128 format |
 
 > ❗ Not supported: `dict`, `set`, `tuple`, `frozenset`, or other complex built-in containers.

--- a/mongo_validations_generator/__init__.py
+++ b/mongo_validations_generator/__init__.py
@@ -1,4 +1,11 @@
-from .core import MongoValidator as MongoValidator
-from .bson_type import BSONType as BSONType
-from .custom_types import Long as Long
-from .custom_types import SchemaIgnored as SchemaIgnored
+from .core import MongoValidator
+from .bson_type import BSONType
+from .custom_types import Long, SchemaIgnored, BSONDecimal128
+
+__all__ = [
+    "MongoValidator",
+    "BSONType",
+    "Long",
+    "SchemaIgnored",
+    "BSONDecimal128",
+]

--- a/mongo_validations_generator/bson_type.py
+++ b/mongo_validations_generator/bson_type.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 from typing import Any, List, Type, get_origin
-from mongo_validations_generator.custom_types import Long
+from mongo_validations_generator.custom_types import Long, BSONDecimal128
 
 
 class BSONType(StrEnum):
@@ -12,6 +12,7 @@ class BSONType(StrEnum):
     NULL = "null"
     INT = "int"
     LONG = "long"
+    DECIMAL128 = "decimal"
 
 
 TYPE_MAP: dict[Type[Any], str] = {
@@ -22,6 +23,7 @@ TYPE_MAP: dict[Type[Any], str] = {
     list: BSONType.ARRAY.value,
     type(None): BSONType.NULL.value,
     Long: BSONType.LONG.value,
+    BSONDecimal128: BSONType.DECIMAL128.value,
 }
 
 

--- a/mongo_validations_generator/bson_type.py
+++ b/mongo_validations_generator/bson_type.py
@@ -42,7 +42,7 @@ def get_bson_type_for(type_hint: Any) -> str | None:
     """
     for base in TYPE_MAP:
         if type_hint is bool:
-            return TYPE_MAP[bool]
+            return BSONType.BOOL.value
 
         if isinstance(type_hint, type) and issubclass(type_hint, base):
             return TYPE_MAP[base]
@@ -50,6 +50,6 @@ def get_bson_type_for(type_hint: Any) -> str | None:
     origin = get_origin(type_hint)
 
     if origin in (list, List):
-        return TYPE_MAP.get(list)
+        return BSONType.ARRAY.value
 
     return None

--- a/mongo_validations_generator/custom_types.py
+++ b/mongo_validations_generator/custom_types.py
@@ -36,10 +36,10 @@ class BSONDecimal128:
                 {"value": value},
             )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"BSONDecimal128({str(self)})"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.value)
 
     def to_decimal(self) -> Decimal:

--- a/mongo_validations_generator/custom_types.py
+++ b/mongo_validations_generator/custom_types.py
@@ -1,6 +1,82 @@
+from decimal import Decimal
+from typing import Any, Sequence, Tuple, Union
+from bson import Decimal128
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic_core import PydanticCustomError
+from pydantic_core.core_schema import (
+    CoreSchema,
+    json_or_python_schema,
+    no_info_plain_validator_function,
+    plain_serializer_function_ser_schema,
+)
+
+
+_DecimalConvertible = Union[Decimal, str, Tuple[int, Sequence[int], int]]
+
+
 class Long:
     pass
 
 
 class SchemaIgnored:
     pass
+
+
+class BSONDecimal128:
+    def __init__(self, value: Decimal128 | _DecimalConvertible):
+        try:
+            if isinstance(value, Decimal128):
+                self.value = value
+            else:
+                self.value = Decimal128(value)
+        except Exception:
+            raise PydanticCustomError(
+                "bson_decimal_conversion",
+                'Cannot convert value "{value}" to BSON Decimal128',
+                {"value": value},
+            )
+
+    def __repr__(self):
+        return f"BSONDecimal128({str(self)})"
+
+    def __str__(self):
+        return str(self.value)
+
+    def to_decimal(self) -> Decimal:
+        return self.value.to_decimal()
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        schema = no_info_plain_validator_function(cls.__validate)
+
+        return json_or_python_schema(
+            json_schema=schema,
+            python_schema=schema,
+            serialization=plain_serializer_function_ser_schema(
+                lambda value: value.to_decimal(),
+                when_used="json",
+            ),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> dict[str, Any]:
+        return {
+            "type": "string",
+            "format": "decimal128",
+            "description": "MongoDB Decimal128 compatible value",
+        }
+
+    @classmethod
+    def __validate(cls, input_value: Any) -> Decimal128:
+        if isinstance(input_value, cls):
+            return input_value.value
+
+        return cls(input_value).value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.10.6",
+    "pymongo>=4.11.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mongo-validations-generator"
-version = "1.0.0"
+version = "1.1.0"
 description = "Generate MongoDB validation schemas from Python type annotations and Pydantic models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_bson_decimal_serialization.py
+++ b/tests/test_bson_decimal_serialization.py
@@ -1,0 +1,88 @@
+from decimal import Decimal
+from typing import Any
+from bson import Decimal128
+from pydantic import ValidationError
+import pytest
+
+from mongo_validations_generator import MongoValidator, BSONDecimal128
+
+
+class PriceModel(MongoValidator):
+    price: BSONDecimal128
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_decimal",
+    [
+        ("123.45", Decimal("123.45")),
+        (Decimal("77.01"), Decimal("77.01")),
+        (Decimal128("42.0"), Decimal("42.0")),
+    ],
+)
+def test_bson_decimal_model_accepts_valid_values(
+    input_value: Any,
+    expected_decimal: Decimal,
+):
+    # Given: A valid value (string, Decimal, or Decimal128) representing a decimal
+    # When: Creating the model with this value
+    model = PriceModel(price=input_value)
+    actual_decimal = model.price.to_decimal()
+
+    # Then: The field must be stored as a Decimal128 and convert to the expected Decimal
+    assert isinstance(model.price, Decimal128)
+    assert actual_decimal == expected_decimal
+
+
+@pytest.mark.parametrize(
+    "invalid_input",
+    [
+        "not_a_number",
+        {},
+        [],
+        True,
+        object(),
+        10,
+        10.0,
+    ],
+)
+def test_bson_decimal_model_rejects_invalid_values(invalid_input: Any):
+    # Given: An invalid input that cannot be converted to BSONDecimal128
+
+    # When / Then: Model instantiation must raise a ValidationError
+    with pytest.raises(ValidationError):
+        PriceModel(price=invalid_input)
+
+
+def test_bson_decimal_serialization_to_decimal():
+    # Given: A model with a decimal price as a string
+    model = PriceModel(price="100.50")  # type: ignore
+
+    # When: Dumping the model to a dictionary
+    data = model.model_dump()
+
+    # Then: The serialized value must be a Decimal128
+    assert data == {"price": Decimal128("100.50")}
+
+
+def test_bson_decimal_str_and_repr():
+    # Given: A BSONDecimal128 instance created from a string
+    instance = BSONDecimal128("19.99")
+
+    # When: Calling str(), repr() and to_decimal()
+    # Then: Outputs should be human-readable and preserve decimal precision
+    assert str(instance) == "19.99"
+    assert "BSONDecimal128" in repr(instance)
+    assert instance.to_decimal() == Decimal("19.99")
+
+
+def test_model_validate_supports_decimal_inputs():
+    # Given: A raw input dictionary with a decimal value as a string
+    raw_input = {"price": "15.75"}
+
+    # When: Validating the input using Pydantic's model_validate
+    model = PriceModel.model_validate(raw_input)
+
+    # Then: The model should be correctly instantiated with a Decimal128 value
+    assert isinstance(model, PriceModel)
+    assert isinstance(model.price, Decimal128)
+    assert model.price.to_decimal() == Decimal("15.75")

--- a/tests/test_generate_basic_bson.py
+++ b/tests/test_generate_basic_bson.py
@@ -1,5 +1,10 @@
 from typing import Annotated, Any
-from mongo_validations_generator import MongoValidator, Long, SchemaIgnored
+from mongo_validations_generator import (
+    MongoValidator,
+    Long,
+    SchemaIgnored,
+    BSONDecimal128,
+)
 
 
 class BasicMockClass(MongoValidator):
@@ -8,11 +13,13 @@ class BasicMockClass(MongoValidator):
     my_float: float
     my_bool: bool
     my_long: Annotated[int, Long]
+    my_decimal: BSONDecimal128
     my_str_optional: str | None
     my_int_optional: int | None
     my_float_optional: float | None
     my_bool_optional: bool | None
     my_long_optional: Annotated[int, Long] | None
+    my_decimal_optional: BSONDecimal128 | None
     my_hidden_property: Annotated[str, SchemaIgnored]
 
 
@@ -29,11 +36,13 @@ def test_basic_bson_generation():
                 "my_float",
                 "my_bool",
                 "my_long",
+                "my_decimal",
                 "my_str_optional",
                 "my_int_optional",
                 "my_float_optional",
                 "my_bool_optional",
                 "my_long_optional",
+                "my_decimal_optional",
             ],
             "properties": {
                 "my_str": {
@@ -56,6 +65,10 @@ def test_basic_bson_generation():
                     "bsonType": "long",
                     "description": "'my_long' must match schema",
                 },
+                "my_decimal": {
+                    "bsonType": "decimal",
+                    "description": "'my_decimal' must match schema",
+                },
                 "my_str_optional": {
                     "oneOf": [{"bsonType": "string"}, {"bsonType": "null"}],
                     "description": "'my_str_optional' must match schema",
@@ -75,6 +88,10 @@ def test_basic_bson_generation():
                 "my_long_optional": {
                     "oneOf": [{"bsonType": "long"}, {"bsonType": "null"}],
                     "description": "'my_long_optional' must match schema",
+                },
+                "my_decimal_optional": {
+                    "oneOf": [{"bsonType": "decimal"}, {"bsonType": "null"}],
+                    "description": "'my_decimal_optional' must match schema",
                 },
             },
         }

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -34,6 +43,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "pymongo" },
 ]
 
 [package.dev-dependencies]
@@ -44,7 +54,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.10.6" }]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pymongo", specifier = ">=4.11.3" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -156,6 +169,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
     { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
     { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/e6/cdb1105c14a86aa2b1663a6cccc6bf54722bb12fb5d479979628142dde42/pymongo-4.11.3.tar.gz", hash = "sha256:b6f24aec7c0cfcf0ea9f89e92b7d40ba18a1e18c134815758f111ecb0122e61c", size = 2054848 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/cf/c606c9d889d8f34dcf80455e045854ef2fa187c439b22a6d30357790c12a/pymongo-4.11.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5f48b7faf4064e5f484989608a59503b11b7f134ca344635e416b1b12e7dc255", size = 895374 },
+    { url = "https://files.pythonhosted.org/packages/c6/f5/287e84ba6c8e34cb13f798e7e859b4dcbc5fab99261f91202a8027f62ba6/pymongo-4.11.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:722f22bf18d208aa752591bde93e018065641711594e7a2fef0432da429264e8", size = 895063 },
+    { url = "https://files.pythonhosted.org/packages/0e/ba/fe8964ec3f8d7348e9cd6a11864e1e84b2be62ea98ca0ba01a4f5b4d417d/pymongo-4.11.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5be1b35c4897626327c4e8bae14655807c2bc710504fa790bc19a72403142264", size = 1673722 },
+    { url = "https://files.pythonhosted.org/packages/92/89/925b7160c517b66c80d05b36f63d4cc0d0ff23f01b5150b55936b5fab097/pymongo-4.11.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14f9e4d2172545798738d27bc6293b972c4f1f98cce248aa56e1e62c4c258ca7", size = 1737946 },
+    { url = "https://files.pythonhosted.org/packages/f8/97/bcedba78ddbc1b8837bf556da55eb08a055e93b331722ecd1dad602a3427/pymongo-4.11.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd3f7bafe441135f58d2b91a312714f423e15fed5afe3854880c8c61ad78d3ce", size = 1706981 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/63719be395ec29b8f71fd267014af4957736b5297a1f51f76ef32d05a0cf/pymongo-4.11.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73de1b9f416a2662ba95b4b49edc963d47b93760a7e2b561b932c8099d160151", size = 1676948 },
+    { url = "https://files.pythonhosted.org/packages/c1/36/de366cee39e6c2e64d824d1f2e5672381ec766c51224304d1aebf7db3507/pymongo-4.11.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e24268e2d7ae96eab12161985b39e75a75185393134fc671f4bb1a16f50bf6f4", size = 1636072 },
+    { url = "https://files.pythonhosted.org/packages/07/48/34751291a152e8098b4cf6f467046f00edd71b695d5cf6be1b15778cda63/pymongo-4.11.3-cp312-cp312-win32.whl", hash = "sha256:33a936d3c1828e4f52bed3dad6191a3618cc28ab056e2770390aec88d9e9f9ea", size = 864025 },
+    { url = "https://files.pythonhosted.org/packages/96/8a/604fab1e1f45deb0dc19e06053369e7db44e3d1359a39e0fe376bdb95b41/pymongo-4.11.3-cp312-cp312-win_amd64.whl", hash = "sha256:c4673d8ef0c8ef712491a750adf64f7998202a82abd72be5be749749275b3edb", size = 882290 },
+    { url = "https://files.pythonhosted.org/packages/01/f1/19f8a81ca1ef180983b89e24f8003863612aea358a06d7685566ccc18a87/pymongo-4.11.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5e53b98c9700bb69f33a322b648d028bfe223ad135fb04ec48c0226998b80d0e", size = 949622 },
+    { url = "https://files.pythonhosted.org/packages/67/9a/ae232aa9379a9e6cf325facf0f65176d70520d6a16807f4de2e1ccfb76ec/pymongo-4.11.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8464aff011208cf86eae28f4a3624ebc4a40783634e119b2b35852252b901ef3", size = 949299 },
+    { url = "https://files.pythonhosted.org/packages/70/6d/1ddef8b6c6d598fe21c917d93c49a6304611a252a07e98a9b7e70e1b995b/pymongo-4.11.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3742ffc1951bec1450a5a6a02cfd40ddd4b1c9416b36c70ae439a532e8be0e05", size = 1937616 },
+    { url = "https://files.pythonhosted.org/packages/13/9c/e735715789a876140f453def1b2015948708d224f1728f9b8412b6e495d2/pymongo-4.11.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a29294b508975a5dfd384f4b902cd121dc2b6e5d55ea2be2debffd2a63461cd9", size = 2015041 },
+    { url = "https://files.pythonhosted.org/packages/fc/d3/cf41e9ce81644de9d8db54cc039823863e7240e021466ae093edc061683a/pymongo-4.11.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:051c741586ab6efafe72e027504ac4e5f01c88eceec579e4e1a438a369a61b0c", size = 1978716 },
+    { url = "https://files.pythonhosted.org/packages/be/c8/c3f15c6cc5a9e0a75d18ae86209584cb14fdca017197def9741bff19c151/pymongo-4.11.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b05e03a327cdef28ec2bb72c974d412d308f5cf867a472ef17f9ac95d18ec05", size = 1939524 },
+    { url = "https://files.pythonhosted.org/packages/1b/0d/613cd91c736325d05d2d5d389d06ed899bcdce5a265cb486b948729bf1eb/pymongo-4.11.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dafeddf1db51df19effd0828ae75492b15d60c7faec388da08f1fe9593c88e7a", size = 1888960 },
+    { url = "https://files.pythonhosted.org/packages/e7/eb/b1e9cf2e03a47c4f35ffc5db1cb0ed0f92c5fe58c6f5f04d5a2da9d6bb77/pymongo-4.11.3-cp313-cp313-win32.whl", hash = "sha256:40c55afb34788ae6a6b8c175421fa46a37cfc45de41fe4669d762c3b1bbda48e", size = 910370 },
+    { url = "https://files.pythonhosted.org/packages/77/f3/023f12ee9028f341880016fd6251255bf755f70730440ad11bf745f5f9e4/pymongo-4.11.3-cp313-cp313-win_amd64.whl", hash = "sha256:a5b8b7ba9614a081d1f932724b7a6a20847f6c9629420ae81ce827db3b599af2", size = 932930 },
+    { url = "https://files.pythonhosted.org/packages/d3/c7/0a145cc66fc756cea547b948150583357e5518cfa60b3ad0d3266d3ee168/pymongo-4.11.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0f23f849693e829655f667ea18b87bf34e1395237eb45084f3495317d455beb2", size = 1006138 },
+    { url = "https://files.pythonhosted.org/packages/81/88/4ed3cd03d2f7835393a72ed87f5e9186f6fc54bcb0e9b7f718424c0b5db8/pymongo-4.11.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:62bcfa88deb4a6152a7c93bedd1a808497f6c2881424ca54c3c81964a51c5040", size = 1006125 },
+    { url = "https://files.pythonhosted.org/packages/91/a9/d86844a9aff958c959e84b8223b9d226c3b39a71f2f2fbf2aa3a4a748212/pymongo-4.11.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2eaa0233858f72074bf0319f5034018092b43f19202bd7ecb822980c35bfd623", size = 2266315 },
+    { url = "https://files.pythonhosted.org/packages/1d/06/fff82b09382a887dab6207bb23778395c5986a5ddab6f55905ebdd82e10c/pymongo-4.11.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a434e081017be360595237cd1aeac3d047dd38e8785c549be80748608c1d4ca", size = 2353538 },
+    { url = "https://files.pythonhosted.org/packages/5d/f7/ff5399baee5888eb686c1508d28b4e9d82b9da5ca63215f958356dee4016/pymongo-4.11.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3e8aa65a9e4a989245198c249816d86cb240221861b748db92b8b3a5356bd6f1", size = 2312410 },
+    { url = "https://files.pythonhosted.org/packages/b0/4d/1746ee984b229eddf5f768265b553a90b31b2395fb5ae1d30d28e430a862/pymongo-4.11.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0a91004029d1fc9e66a800e6da4170afaa9b93bcf41299e4b5951b837b3467a", size = 2263706 },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/5d4154c5baf62af9ffb9391cf41848a87cda97798f92e4336730690be7d5/pymongo-4.11.3-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1b992904ac78cb712b42c4b7348974ba1739137c1692cdf8bf75c3eeb22881a4", size = 2202724 },
+    { url = "https://files.pythonhosted.org/packages/72/15/c18fcc456fdcb793714776da273fc4cba4579f21818f2219e23ff9512314/pymongo-4.11.3-cp313-cp313t-win32.whl", hash = "sha256:45e18bda802d95a2aed88e487f06becc3bd0b22286a25aeca8c46b8c64980dbb", size = 959256 },
+    { url = "https://files.pythonhosted.org/packages/7d/64/11d87df61cdca4fef90388af592247e17f3d31b15a909780f186d2739592/pymongo-4.11.3-cp313-cp313t-win_amd64.whl", hash = "sha256:07d40b831590bc458b624f421849c2b09ad2b9110b956f658b583fe01fe01c01", size = 987855 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request adds first-class support for BSONDecimal128 as a custom scalar type for BSON schema generation and Pydantic model integration.

## Pre-merge Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I ran `ruff format .` and `ruff check .` to ensure style compliance.
- [x] I ran `mypy mongo_validations_generator` and resolved any typing issues.
- [x] I updated `pyproject.toml` with an appropriate new version.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added or updated tests as needed, or this change does not require new tests.
- [x] All existing tests are passing.


<!-- Links -->

[Contributor Guide]: https://github.com/all-win-solutions/mongo-validations-generator/blob/main/CONTRIBUTING.md
