### PR TITLE
Add enum type support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ _Replace this paragraph with a description of what this PR is changing or adding
 - [ ] I ran `mypy mongo_validations_generator` and resolved any typing issues.
 - [ ] I updated `pyproject.toml` with an appropriate new version.
 - [ ] I updated `CHANGELOG.md` to add a description of the change.
-- [ ] I updated/added relevant documentation (doc comments with `///`).
+- [ ] I updated/added relevant documentation (doc comments with `"""`).
 - [ ] I added or updated tests as needed, or this change does not require new tests.
 - [ ] All existing tests are passing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.0
+
+- Added native support for Python's standard library `Enum` type:
+  - Fields defined with `Enum` are now automatically mapped to the BSON `enum` validator.
+  - This behaves similarly to `Literal`, generating a list of allowed values in the schema.
+- Added new tests to ensure correct schema generation for Enum fields.
+
 ## 1.1.0
 
 - Support for `BSONDecimal128` as a custom scalar type:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The following BSON types are currently supported by the schema generator:
 | `None` / `Optional[...]`       | `"null"`    | Supports `Union[Type, None]` and `Optional[...]`                     |
 | `Annotated[int, Long]`         | `"long"`    | Use `Annotated[int, Long]` to convert to `"long"`                    |
 | `Literal[...]`                 | `"enum"`    | Will emit enum values and infer BSON type if homogeneous             |
+| `Enum` / `StrEnum` / `IntEnum` | `"enum"`    | Maps to the BSON enum validator using the enum's members             |
 | `MongoValidator` subclass      | `"object"`  | Nested objects are fully supported                                   |
 | `Annotated[list[T], Len(...)]` | `"array"`   | Adds `minItems` and `maxItems` constraints to list validation        |
 | `BSONDecimal128`               | `"decimal"` | Outputs a decimal-compatible field using MongoDB's Decimal128 format |

--- a/mongo_validations_generator/bson_type.py
+++ b/mongo_validations_generator/bson_type.py
@@ -1,4 +1,4 @@
-from enum import StrEnum
+from enum import Enum, StrEnum
 from typing import Any, List, Type, get_origin
 from mongo_validations_generator.custom_types import Long, BSONDecimal128
 
@@ -6,6 +6,7 @@ from mongo_validations_generator.custom_types import Long, BSONDecimal128
 class BSONType(StrEnum):
     DOUBLE = "double"
     STRING = "string"
+    ENUM = "enum"
     OBJECT = "object"
     ARRAY = "array"
     BOOL = "bool"
@@ -16,6 +17,7 @@ class BSONType(StrEnum):
 
 
 TYPE_MAP: dict[Type[Any], str] = {
+    Enum: BSONType.ENUM,
     str: BSONType.STRING.value,
     int: BSONType.INT.value,
     float: BSONType.DOUBLE.value,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mongo-validations-generator"
-version = "1.1.0"
+version = "1.2.0"
 description = "Generate MongoDB validation schemas from Python type annotations and Pydantic models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_generate_basic_bson.py
+++ b/tests/test_generate_basic_bson.py
@@ -1,3 +1,4 @@
+from enum import Enum, StrEnum
 from typing import Annotated, Any
 from mongo_validations_generator import (
     MongoValidator,
@@ -7,6 +8,18 @@ from mongo_validations_generator import (
 )
 
 
+class StatusMockClass(StrEnum):
+    LOADING = "loading"
+    SUCCESS = "success"
+    FAILURE = "failure"
+
+
+class EnumMockClass(Enum):
+    MY_MEMBER_ONE = "one"
+    MY_MEMBER_TWO = 2
+    MY_MEMBER_THREE = "three"
+
+
 class BasicMockClass(MongoValidator):
     my_str: str
     my_int: int
@@ -14,10 +27,14 @@ class BasicMockClass(MongoValidator):
     my_bool: bool
     my_long: Annotated[int, Long]
     my_decimal: BSONDecimal128
+    my_status: StatusMockClass
+    my_enum: EnumMockClass
     my_str_optional: str | None
     my_int_optional: int | None
     my_float_optional: float | None
     my_bool_optional: bool | None
+    my_status_optional: StatusMockClass | None
+    my_enum_optional: EnumMockClass | None
     my_long_optional: Annotated[int, Long] | None
     my_decimal_optional: BSONDecimal128 | None
     my_hidden_property: Annotated[str, SchemaIgnored]
@@ -37,10 +54,14 @@ def test_basic_bson_generation():
                 "my_bool",
                 "my_long",
                 "my_decimal",
+                "my_status",
+                "my_enum",
                 "my_str_optional",
                 "my_int_optional",
                 "my_float_optional",
                 "my_bool_optional",
+                "my_status_optional",
+                "my_enum_optional",
                 "my_long_optional",
                 "my_decimal_optional",
             ],
@@ -69,6 +90,15 @@ def test_basic_bson_generation():
                     "bsonType": "decimal",
                     "description": "'my_decimal' must match schema",
                 },
+                "my_status": {
+                    "enum": ["loading", "success", "failure"],
+                    "bsonType": "string",
+                    "description": "'my_status' must match schema",
+                },
+                "my_enum": {
+                    "enum": ["one", 2, "three"],
+                    "description": "'my_enum' must match schema",
+                },
                 "my_str_optional": {
                     "oneOf": [{"bsonType": "string"}, {"bsonType": "null"}],
                     "description": "'my_str_optional' must match schema",
@@ -84,6 +114,25 @@ def test_basic_bson_generation():
                 "my_bool_optional": {
                     "oneOf": [{"bsonType": "bool"}, {"bsonType": "null"}],
                     "description": "'my_bool_optional' must match schema",
+                },
+                "my_status_optional": {
+                    "oneOf": [
+                        {
+                            "enum": ["loading", "success", "failure"],
+                            "bsonType": "string",
+                        },
+                        {"bsonType": "null"},
+                    ],
+                    "description": "'my_status_optional' must match schema",
+                },
+                "my_enum_optional": {
+                    "oneOf": [
+                        {
+                            "enum": ["one", 2, "three"],
+                        },
+                        {"bsonType": "null"},
+                    ],
+                    "description": "'my_enum_optional' must match schema",
                 },
                 "my_long_optional": {
                     "oneOf": [{"bsonType": "long"}, {"bsonType": "null"}],

--- a/tests/test_generate_bson_for_list.py
+++ b/tests/test_generate_bson_for_list.py
@@ -1,7 +1,14 @@
+from enum import StrEnum
 from typing import Annotated, Any, List, Literal, Optional
 
 from annotated_types import Len
 from mongo_validations_generator import MongoValidator
+
+
+class StatusMockClass(StrEnum):
+    LOADING = "loading"
+    SUCCESS = "success"
+    FAILURE = "failure"
 
 
 class MockClass(MongoValidator):
@@ -10,6 +17,7 @@ class MockClass(MongoValidator):
     my_float_list: list[float]
     my_optional_list: list[str] | None
     my_int_or_bool_list: list[int | bool]
+    my_enum_list: list[StatusMockClass]
 
 
 class MyMockListClass(MongoValidator):
@@ -40,6 +48,7 @@ expected_mock_class_bson_schema: dict[str, Any] = {
         "my_float_list",
         "my_optional_list",
         "my_int_or_bool_list",
+        "my_enum_list",
     ],
     "properties": {
         "my_str_list": {
@@ -71,6 +80,14 @@ expected_mock_class_bson_schema: dict[str, Any] = {
             "bsonType": "array",
             "items": {"oneOf": [{"bsonType": "int"}, {"bsonType": "bool"}]},
             "description": "'my_int_or_bool_list' must match schema",
+        },
+        "my_enum_list": {
+            "bsonType": "array",
+            "items": {
+                "enum": ["loading", "success", "failure"],
+                "bsonType": "string",
+            },
+            "description": "'my_enum_list' must match schema",
         },
     },
 }

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "mongo-validations-generator"
-version = "1.0.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request adds first-class support for Python's standard Enum type, automatically mapping its members to the BSON enum validator for schema generation.

## Pre-merge Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I ran `ruff format .` and `ruff check .` to ensure style compliance.
- [x] I ran `mypy mongo_validations_generator` and resolved any typing issues.
- [x] I updated `pyproject.toml` with an appropriate new version.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added or updated tests as needed, or this change does not require new tests.
- [x] All existing tests are passing.


<!-- Links -->

[Contributor Guide]: https://github.com/all-win-solutions/mongo-validations-generator/blob/main/CONTRIBUTING.md
